### PR TITLE
fix: Update build.gradle to support new agp versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.example.flutter_silero_vad"
+    
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
AGP version >=8.0.0 requires the namespace attribute in the build.gradle, not on the AndroidManifest.xml. This was stopping me from compiling when I updated java and gradle. 